### PR TITLE
Allow `wait_for` to take a default timeout argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # rspec failure tracking
 .rspec_status
+*.gem

--- a/lib/chrome_remote/client.rb
+++ b/lib/chrome_remote/client.rb
@@ -31,13 +31,15 @@ module ChromeRemote
       read_until { false }
     end
 
-    def wait_for(event_name=nil)
-      if event_name
-        msg = read_until { |msg| msg["method"] == event_name }
-      elsif block_given?
-        msg = read_until { |msg| yield(msg["method"], msg["params"]) }
+    def wait_for(event_name=nil, timeout: nil)
+      Timeout::timeout(timeout) do
+        if event_name
+          msg = read_until { |msg| msg["method"] == event_name }
+        elsif block_given?
+          msg = read_until { |msg| yield(msg["method"], msg["params"]) }
+        end
+        Hashie::Mash.new(msg["params"])
       end
-      Hashie::Mash.new(msg["params"])
     end
 
     private

--- a/lib/chrome_remote/version.rb
+++ b/lib/chrome_remote/version.rb
@@ -1,3 +1,3 @@
 module ChromeRemote
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/integration/chrome_remote_spec.rb
+++ b/spec/integration/chrome_remote_spec.rb
@@ -211,5 +211,18 @@ RSpec.describe ChromeRemote do
 
       expect(result).to eq({"name" => "DOMContentLoaded"})
     end
+
+    it "raises a TimeoutException when it passes over the timeout threshold" do
+      thr = Thread.new do
+        sleep(2)
+        server.send_msg({ method: "Network.requestWillBeSent" }.to_json)
+      end
+
+      expect {
+        client.wait_for("Network.requestWillBeSent", timeout: 1)
+      }.to raise_error(Timeout::Error)
+
+      thr.join
+    end
   end
 end


### PR DESCRIPTION
### Problem:

`wait_for` can potentially spin forever, blocking the calling thread from continuing execution

### Solution

Use Ruby's `Timeout::timeout` method to specify a default timeout. A `Timeout::Error` is raised if the timeout exceeds the provided threshold. The default threshold is `nil`, or infinity (no timeout).